### PR TITLE
random fixes

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "TrunkFingerprint",
    "abstract": "This thing calculates a fingerprint of DB structure",
    "description": "This thing calculates a fingerprint of DB structure",
-   "version": "1.1.5",
+   "version": "1.1.6",
    "maintainer": "Alexey Bashtanov <bashtanov@imap.cc>",
    "license": {
       "PostgreSQL": "http://www.postgresql.org/about/licence"
@@ -19,9 +19,9 @@
    },
    "provides": {
      "trunkfingerprint": {
-       "file": "trunkfingerprint--1.1.5.sql",
+       "file": "trunkfingerprint--1.1.6.sql",
        "docfile": "README.md",
-       "version": "1.1.5"
+       "version": "1.1.6"
      }
    },
    "release_status": "stable",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = trunkfingerprint
-DATA = trunkfingerprint--1.1.5.sql
+DATA = trunkfingerprint--1.1.6.sql
 
 TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+trunkfingerprint (1.1.6-1) unstable; urgency=medium
+
+  * ignore pg_constraint.conkey order for check constraints
+  * flatten multiline expressions when printing column headers for detailed
+    diffs
+
+ --  <alexey@ev9d9.btn1.brandwatch.net>  Mon, 19 Apr 2021 16:45:05 +0100
+
 trunkfingerprint (1.1.5-1) unstable; urgency=medium
 
   * support declarative partitoning

--- a/trunkfingerprint.control
+++ b/trunkfingerprint.control
@@ -1,5 +1,5 @@
 comment = 'This thing calculates a fingerprint of DB structure, and of the data if requested'
-default_version = '1.1.5'
+default_version = '1.1.6'
 relocatable = false
 superuser = false
 schema = trunkfingerprint


### PR DESCRIPTION
1. ignore items order in `pg_constraint.conkey` for check constraints, as it's just a list of columns used in the constraint definition
2. print expressions used to generate diffed tuples even if they are complicated and contain whitespace and newlines