### PR TITLE
  Build for Postgres 13

### DIFF
--- a/debian/pgversions
+++ b/debian/pgversions
@@ -1,2 +1,3 @@
-# Other versions are not in use
+# Versions of Postgres to build against
 10
+13


### PR DESCRIPTION
add postgres 13

it's guaranteed to fail, but at least it's going to be present and the docker image will build and run

I'll fix the functionality later